### PR TITLE
Fix incomplete Telegram health command

### DIFF
--- a/1_py/part1/bot.py
+++ b/1_py/part1/bot.py
@@ -273,3 +273,4 @@ async def health_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             f"Markets={','.join(CONFIG.MARKETS)}, "
             f"Risk={CONFIG.RISK_PERCENT}%"
         )
+        await context.bot.send_message(chat_id=chat.id, text=info)


### PR DESCRIPTION
## Summary
- ensure `health_command` replies with bot status

## Testing
- `python -m py_compile 1_py/part1/bot.py`
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68419a8937848332bd1b16e881be34c0