### PR TITLE
Fix typo in fontTools merger comment

### DIFF
--- a/1_py/part19/MAGUS_PRIME_X_RELEASE_main_.conda_Lib_site-packages_fontTools_varLib_merger.py
+++ b/1_py/part19/MAGUS_PRIME_X_RELEASE_main_.conda_Lib_site-packages_fontTools_varLib_merger.py
@@ -989,7 +989,7 @@ def merge(merger, self, lst):
                 # with all value records set to the rec format type.
                 # We use buildSinglePos() to optimize the lookup after merging.
                 valueFormatList = [t.ValueFormat for st in subtables for t in st]
-                # Find the minimum value record that can accomodate all the singlePos subtables.
+                # Find the minimum value record that can accommodate all the singlePos subtables.
                 mirf = reduce(ior, valueFormatList)
                 self.SubTable = _Lookup_SinglePos_subtables_flatten(
                     self.SubTable, merger.font, mirf


### PR DESCRIPTION
## Summary
- fix a spelling mistake in `fontTools_varLib_merger.py`

## Testing
- `pytest -q` *(fails: ImportError and SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_6844a718473083328163247ebfecca45