### PR TITLE
Fix ML prediction log formatting

### DIFF
--- a/1_py/part1/MAGUS PRIME X 2_extended_test.py
+++ b/1_py/part1/MAGUS PRIME X 2_extended_test.py
@@ -95,11 +95,10 @@ def extended_test():
                 )
                 if prediction:
                     logger.info(
-                        f" "
-ML Prediction - Direction: {
-                                                            prediction.d + "irection},
-                                                            Confidence: {prediction.confi + "dence:.2f},
-                                                            Expected Return: {prediction + ".expected_return:.2f}%"                    )
+                        f"ML Prediction - Direction: {prediction.direction}, "
+                        f"Confidence: {prediction.confidence:.2f}, "
+                        f"Expected Return: {prediction.expected_return:.2f}%"
+                    )
                 else:
                     logger.info("No ML prediction available")
 


### PR DESCRIPTION
## Summary
- clean up ML prediction logging output in extended test

## Testing
- `python -m py_compile '1_py/part1/MAGUS PRIME X 2_extended_test.py'` *(fails: invalid decimal literal)*

------
https://chatgpt.com/codex/tasks/task_e_6844a8d9a8bc8332827b50932b37b0f6