### PR TITLE
Convert ATR test to assertions

### DIFF
--- a/1_py/part1/BLACKBOX AI_trading-bot_test_atr.py
+++ b/1_py/part1/BLACKBOX AI_trading-bot_test_atr.py
@@ -1,6 +1,12 @@
+import os
+from importlib.machinery import SourceFileLoader
 import pandas as pd
 import numpy as np
-from src.technical_indicators import calculate_atr
+
+# Load the calculate_atr function directly from the sibling module
+module_path = os.path.join(os.path.dirname(__file__), "BLACKBOX AI_trading-bot_src_technical_indicators.py")
+technical_indicators = SourceFileLoader("technical_indicators", module_path).load_module()
+calculate_atr = technical_indicators.calculate_atr
 
 def test_atr():
     # Create sample price data
@@ -13,11 +19,12 @@ def test_atr():
     
     # Calculate ATR with period=3
     atr = calculate_atr(df['high'], df['low'], df['close'], period=3)
-    
-    print("Sample Data:")
-    print(df)
-    print("\nCalculated ATR values:")
-    print(atr)
+
+    expected = np.array([2, 3, 3, 3, 3])
+
+    # Ensure the result is a numpy array with the expected values
+    assert isinstance(atr, np.ndarray)
+    assert np.array_equal(atr, expected)
 
 if __name__ == "__main__":
-    test_atr()
+    raise SystemExit("Run this test using pytest or unittest, not as a script")


### PR DESCRIPTION
## Summary
- swap manual printouts for `assert` statements in ATR test
- load `calculate_atr` from sibling file directly
- prevent running the file as a script

## Testing
- `pytest -q '1_py/part1/BLACKBOX AI_trading-bot_test_atr.py'`

------
https://chatgpt.com/codex/tasks/task_e_6844a914522883328a5f42e7700de9db